### PR TITLE
Skip git repository creation when already in a git repository

### DIFF
--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const fs = require('fs-extra');
+const { spawnSync } = require('child_process');
 const chalk = require('chalk');
 const Command = require('../models/command');
 const RSVP = require('rsvp');
@@ -46,7 +47,10 @@ module.exports = Command.extend({
       return Promise.reject(new SilentError(message));
     }
 
-    if (commandOptions.dryRun) {
+    const inRepo = spawnSync('git', ['rev-parse',
+                                     '--is-inside-work-tree']);
+
+    if (commandOptions.dryRun || inRepo.status === 0) {
       commandOptions.skipGit = true;
     }
 


### PR DESCRIPTION
This will be very common for monorepo setups, so don't make users pass `--skip-git` every time if they're inside an existing repository.