### PR TITLE
serve the app from GET /app/

### DIFF
--- a/lib/models/server/app-api.js
+++ b/lib/models/server/app-api.js
@@ -1,9 +1,16 @@
+const fs = require("fs");
+const path = require("path");
+const yaml = require("js-yaml");
+const { promisify } = require("util");
+
+const readFile = promisify(fs.readFile);
+
 module.exports = function(root) {
   return function(req, res) {
     if (req.method === "GET") {
-      res.end(
-        "This method is only accessible via POST, from the Studio Dev Editor. Otherwise there won't be any injected MI.options."
-      );
+      getIndexPath(root).then(path => {
+        res.sendFile(path);
+      });
       return;
     }
 
@@ -16,3 +23,17 @@ module.exports = function(root) {
     res.end(content);
   };
 };
+
+async function getIndexPath(root) {
+  const manifestPath = path.join(root, "manifest.yml");
+  const manifestData = await readFile(manifestPath);
+  let manifest = yaml.safeLoad(manifestData);
+
+  const htmlLocation = manifest.html_file || "index.html";
+  const fullPath = path.resolve(root, htmlLocation);
+  if (fullPath.indexOf(root) === 0 && fs.existsSync(fullPath)) {
+    return fullPath;
+  } else {
+    throw("Unable to load html file from manifest");
+  }
+}


### PR DESCRIPTION
Before this, we only allow POST to `/app`, which allows canvas to compile the html with `MI.options`, etc. But sometimes you really just need a `GET` (for testing on iphone, for instance) and so now `GET` returns the html without any options injected.