### PR TITLE
add api to send mdk version

### DIFF
--- a/lib/models/server/index.js
+++ b/lib/models/server/index.js
@@ -9,6 +9,7 @@ const fontApi = require("./font-api");
 const picApi = require("./pic-api");
 const saveApi = require("./save-api");
 const dataSourceApi = require("./data-source-api");
+const versionApi = require("./version-api");
 const liveReload = require("./live-reload");
 
 const canvasUrls = {
@@ -41,6 +42,7 @@ module.exports = function(root, liveReloadPort) {
   server.put("/api/canvas/data_sources/:id", dataSourceApi.put(root));
   server.delete("/api/canvas/data_sources/:id", dataSourceApi.delete(root));
 
+  server.get("/api/version", versionApi());
   server.use("/studio-live-reload", liveReload(liveReloadPort));
 
   server.use(function(req, res, next) {

--- a/lib/models/server/version-api.js
+++ b/lib/models/server/version-api.js
@@ -1,0 +1,11 @@
+const package = require('../../../package.json');
+
+module.exports = function versionApi() {
+  return function(req, res) {
+    res.writeHead(200, {'Content-Type': 'application/json'});
+    res.end(JSON.stringify({
+      mdk: package.version,
+      node: process.versions.node
+    }));
+  };
+};


### PR DESCRIPTION
The UI side comes out like this:

![image](https://user-images.githubusercontent.com/3705/36355291-ec86ef22-14ae-11e8-9879-45d244d43463.png)

This will let us notify users that they're using an older version of the MDK and should upgrade. Right now it's super-minimal, just a `title` attribute on a span. Eventually we'll probably want a modal telling users to `yarn global add @movable/cli`.