### PR TITLE
increase POST limits from 100kb to 20MB

### DIFF
--- a/lib/models/server/index.js
+++ b/lib/models/server/index.js
@@ -25,8 +25,8 @@ const canvasUrl = canvasUrls[environment];
 module.exports = function(root, liveReloadPort) {
   let server = express();
 
-  server.use(bodyParser.urlencoded({ extended: false }));
-  server.use(bodyParser.json());
+  server.use(bodyParser.urlencoded({ extended: false, limit: '20mb' }));
+  server.use(bodyParser.json({limit: '20mb'}));
 
   server.use("/app/dist", express.static(path.join(root, "/dist")));
   server.use("/app", express.static(path.join(root, "/app")));


### PR DESCRIPTION
It turns out that it's very possible that apps' CSS+HTML+Javascript is > 100kb, there isn't any particular security issue here so let's make sure we never have to raise it again. (at least for text POSTs)