### PR TITLE
ensure that we can create new movable projects inside a yarn workspace

### DIFF
--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -42,6 +42,11 @@ class Project extends EmberProject {
     let pkg = fs.readJsonSync(path.join(directory, 'package.json'));
     logger.info('project name: %s', pkg && pkg.name);
 
+    if(isYarnWorkspacesProject(pkg)) {
+      logger.info('ignoring parent project since we are in a monorepo');
+      return Project.nullProject(_ui, _cli);
+    }
+
     if (!isMovableCliProject(pkg)) {
       logger.info('ignoring parent project since it is not an ember-cli project');
       // Someday we will error on this, but not today.
@@ -122,6 +127,10 @@ function findupPath(pathName) {
   }
 
   return path.dirname(pkgPath);
+}
+
+function isYarnWorkspacesProject(pkg) {
+  return pkg && pkg.workspaces;
 }
 
 function isMovableCliProject(pkg) {


### PR DESCRIPTION
Fixes https://github.com/movableink/movable-cli/issues/17.

Inside the monorepo, we look to the parent directory, see that it has a `package.json`, and assume we're inside a project. This adds a check to see if it's actually a yarn workspace and ignore it.