### PR TITLE
Uses the latest Cropduster in app blueprint

### DIFF
--- a/blueprints/app/files/package.json
+++ b/blueprints/app/files/package.json
@@ -16,7 +16,7 @@
   "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "",
   "dependencies": {
-    "cropduster": "^4.1.0",
+    "cropduster": "^6.0.0",
     "jquery": "^3.2.1",
     "studio-app": "^1.1.0"
   },


### PR DESCRIPTION
@spencer516 's recent [cropduster update](https://github.com/movableink/cropduster/pull/33) reminded me that `movable new / init` adds a really old Cropduster dependency to the `package.json`.