### PR TITLE
remove object destructuring for now, node 8.1 does not support it

### DIFF
--- a/lib/models/server/data-source-api.js
+++ b/lib/models/server/data-source-api.js
@@ -16,14 +16,13 @@ async function getSampleDataSources(root) {
   return Object.entries(definitions).reduce((sources, [templateType, definition]) => {
     const samples = definition.sample_responses || [];
     samples.forEach(sample => {
-      sources.push({
-        ...sample,
+      sources.push(Object.assign({}, sample, {
         type: 'ApiDataSource',
         id: sample.name,
         key: encodeURIComponent(sample.name),
         url: '/not-real',
         template_type: templateType
-      });
+      }));
     });
 
     return sources;


### PR DESCRIPTION
Apparently support was added in 8.3/8.4, and we support node >= 8, so we'll hold off on using this sort of destructuring.