### PR TITLE
use http urls for external capture for now, rather than https

### DIFF
--- a/lib/models/server/preview-proxy.js
+++ b/lib/models/server/preview-proxy.js
@@ -24,7 +24,7 @@ exports.ensureTunnel = function(server) {
 
     proxy.connect().then((proxyInfo) => {
       debug(`Proxy tunnel established, endpoint is at ${proxyInfo.uri}`);
-      req.tunnelUrl = proxyInfo.uri;
+      req.tunnelUrl = proxyInfo.uri.replace(/^https/, 'http');
       next();
     }).catch((e) => {
       debug(`Tunnel creation failed: ${e.toString()}`);


### PR DESCRIPTION
Some apps include references to `http` assets, so if capturama loads the mdk page from an https URL those assets will throw insecure content warnings.