### PR TITLE
Monorepos can deploy a single app at a time

### DIFF
--- a/lib/models/git-remote.js
+++ b/lib/models/git-remote.js
@@ -6,6 +6,7 @@
 
 const execa = require('execa');
 const url = require('url');
+const path = require('path');
 
 const remotes = {
   development: 'http://localhost:4044',
@@ -96,24 +97,32 @@ class GitRemote {
   }
 
   /**
-    Generate a unique deploy tag name, based on the environment and a timestamp.
+    Generate a unique deploy tag name, based on the environment and a timestamp. If
+    the repo is a monorepo, the deployId will incorporate the passed `appName` to
+    specify which app to build.
 
     @public
     @method makeDeployId
   */
-  makeDeployId() {
+  makeDeployId(appName) {
     const timestamp = new Date().toLocaleString().replace(/\s|:/g, '-');
-    return `${this.name}-${timestamp}`;
+
+    if (appName) {
+      return `${this.name}/${appName}/-${timestamp}`;
+    } else {
+      return `${this.name}-${timestamp}`;
+    }
   }
 
   /**
-    Tags the current git commit with a new tag, returning the tag name.
+    Tags the current git commit with a new tag, returning the tag name. If the repo
+    is a monorepo, the passed `appName` will be incorporated into the tag name.
 
     @public
     @method createTag
   */
-  createTag() {
-    const tagName = this.makeDeployId();
+  createTag(appName) {
+    const tagName = this.makeDeployId(appName);
     return this.git('tag', '-a', '-m', tagName, tagName).then(() => tagName);
   }
 
@@ -125,6 +134,37 @@ class GitRemote {
   */
   push(tagName) {
     return this.git('push', this.name, tagName);
+  }
+
+  /**
+    Returns the directory name of this repository
+
+    @public
+    @method repoName
+  */
+  repoName() {
+    return this.directory().then(dir => path.basename(dir));
+  }
+
+  /**
+    Returns the directory path of this repository
+
+    @public
+    @method directory
+  */
+  directory() {
+    return this.git('rev-parse', '--show-toplevel').then((result) => result.stdout.trim());
+  }
+
+  /**
+    Returns the app name in a monorepo; otherwise returns
+    null.
+  */
+  async appNameForCurrentDir() {
+    const appsDir = 'apps/';
+    const subpath = await this.git('rev-parse', '--show-prefix');
+    const match = subpath.stdout.trim().match(/^apps\/([^\/]+)/);
+    return match && match[1];
   }
 
   /**

--- a/lib/tasks/deploy.js
+++ b/lib/tasks/deploy.js
@@ -45,7 +45,7 @@ class DeployTask extends Task {
           throw(new SilentError(msg));
         }
 
-        const name = this.project.pkg.name;
+        const name = await remote.repoName();
         remote.path = `/${company.slug}/${name}.git`;
         remote.token = auth.token.access_token;
 
@@ -56,7 +56,11 @@ class DeployTask extends Task {
       }
     }
 
-    const tag = await remote.createTag();
+    // For a monorepo, this will return the deploying app's name; otherwise it
+    // will return null
+    const appName = await remote.appNameForCurrentDir();
+
+    const tag = await remote.createTag(appName);
     const push = remote.push(tag);
 
     push.stdout.pipe(ui.outputStream);

--- a/tests/unit/models/git-remote-test.js
+++ b/tests/unit/models/git-remote-test.js
@@ -115,6 +115,34 @@ describe('models/git-remote', function() {
       const result = await remote.createTag();
       expect(result).to.match(/^deploy-development-/);
     });
+
+    it('creates a tag with an app name', async function() {
+      const gitArgs = ['tag', '-a', '-m',
+                       td.matchers.contains(/^deploy-development\/my-app\/-.*/),
+                       td.matchers.contains(/^deploy-development\/my-app\/-.*/)];
+      td.when(remote.git(...gitArgs)).thenResolve('deploy-development\/my-app\/-2018-05-02-10-04');
+
+      const result = await remote.createTag('my-app');
+      expect(result).to.match(/^deploy-development\/my-app\/-/);
+    });
+  });
+
+  describe('#appNameForCurrentDir', function() {
+    it('returns a monorepo app in a monorepo', async function() {
+      const gitArgs = ['rev-parse', '--show-prefix'];
+      td.when(remote.git(...gitArgs)).thenResolve({ stdout: 'apps/my-app/bin\n' });
+
+      const result = await remote.appNameForCurrentDir();
+      expect(result).to.eq('my-app');
+    });
+
+    it('returns null when not in a monorepo', async function() {
+      const gitArgs = ['rev-parse', '--show-prefix'];
+      td.when(remote.git(...gitArgs)).thenResolve({ stdout: 'bin\n' });
+
+      const result = await remote.appNameForCurrentDir();
+      expect(result).to.eq(null);
+    });
   });
 
   describe('#push', function() {


### PR DESCRIPTION
Instead of trying to determine which apps changed since last deploy, the MDK will append the app name to the deploy tag in the form `deploy-production/my-app/-2018-...` to tell the deploy server to only build and deploy `my-app`, rather than all of the apps in the monorepo.