### PR TITLE
be more selective about which routes serve the ember app

### DIFF
--- a/lib/models/server/index.js
+++ b/lib/models/server/index.js
@@ -80,7 +80,7 @@ module.exports = function(root, liveReloadPort) {
     logLevel: "warn"
   });
 
-  server.use("/", canvasProxy);
+  server.use("/dev", canvasProxy);
 
   return server;
 };


### PR DESCRIPTION
Otherwise, if you request a missing file in `/dist`, you end up receiving a copy of the ember app html which is confusing.