### PR TITLE
fix for yarn workspaces

### DIFF
--- a/lib/models/project.js
+++ b/lib/models/project.js
@@ -130,7 +130,7 @@ function findupPath(pathName) {
 }
 
 function isYarnWorkspacesProject(pkg) {
-  return pkg && pkg.workspaces;
+  return pkg && pkg.workspaces && Array.isArray(pkg.workspaces);
 }
 
 function isMovableCliProject(pkg) {


### PR DESCRIPTION
We were detecting if you were at the top of a monorepo via the presence of a `workspaces` attribute in `package.json`, but the `workspaces` can be used at the top level to specify which directories are workspaces, and it can also be used in one of the monorepo's apps to set some options such as `nohoist`. So we check to see if `workspaces` is an array of items to see if it's a monorepo `package.json` or not.