### PR TITLE
support all future manifest additions

### DIFF
--- a/lib/server/pic-api.js
+++ b/lib/server/pic-api.js
@@ -49,17 +49,12 @@ module.exports = function picApi(root) {
 };
 
 function responseObject(manifest) {
-  const manifestRecord = {
-    id: 0,
-    html: manifest.html,
-    javascript: manifest.javascript,
-    css: manifest.css,
-    name: manifest.name,
+  const manifestRecord = Object.assign({}, manifest, {
+    structure: manifest,
+    current_revision: 'git',
     base: '/',
-    advanced_options_exposed: manifest.expose_advanced_options,
-    current_revision: "git",
-    structure: manifest
-  };
+    id: 0
+  });
 
   return {
     custom_pics: [


### PR DESCRIPTION
As we add more attributes to manifest, we want to pick up on them automatically rather than having to enumerate them, so we do that with `Object.assign()`.