### PR TITLE
use production UI by default

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -19,11 +19,12 @@ const staticPicsApi = require("./static-pics-api");
 const oAuthApi = require("./o-auth-api");
 
 const canvasUrls = {
+  production: "https://s3.amazonaws.com/movableink-canvas-production/index.html",
   staging: "https://s3.amazonaws.com/movableink-canvas-staging/index.html",
   development: "http://movableink.localhost:8020/index.html"
 };
 
-const environment = process.env.MOVABLE_ENV || "staging";
+const environment = process.env.MOVABLE_ENV || "production";
 const canvasUrl = canvasUrls[environment];
 
 module.exports = function(root, liveReloadPort) {


### PR DESCRIPTION
Assume `production` environment, we've spent enough time in `staging` at this point. In the future we can use `staging` for testing.