### PR TITLE
Use custom fonts from Studio

### DIFF
--- a/lib/server/font-api.js
+++ b/lib/server/font-api.js
@@ -1,5 +1,20 @@
+const ApiClient = require('../models/api-client');
+const Config = require('../models/config');
+const defaultConfig = require('../defaults');
+
 module.exports = function fontApi() {
-  return function(req, res) {
-    res.end("[]");
+  return async function(req, res) {
+    const userConfig = new Config(defaultConfig.userConfigPath);
+    const client = new ApiClient(Object.assign({}, defaultConfig, { userConfig }));
+
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+
+    try {
+      const fonts = await client.get('/api/v2/custom_fonts');
+      res.end(fonts);
+    } catch(e) {
+      res.end(JSON.stringify({ custom_fonts: [] }));
+      console.error(e.message);
+    }
   };
 };

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "simple-oauth2": "^1.5.2"
   },
   "devDependencies": {
+    "chai-http": "^4.0.0",
     "co": "^4.6.0",
     "ember-cli-internal-test-helpers": "^0.9.1",
     "mocha": "^5.0.5",

--- a/tests/acceptance/server-fonts-test.js
+++ b/tests/acceptance/server-fonts-test.js
@@ -1,0 +1,92 @@
+const url = require('url');
+const chai = require('chai');
+const chaiHttp = require('chai-http');
+const server = require('../../lib/server/index');
+const Config = require('../../lib/models/config');
+const defaultConfig = require('../../lib/defaults');
+const nock = require('nock');
+
+defaultConfig.userConfigPath = './tmp/.mdk';
+defaultConfig.dashboardURL = 'http://dashboard.invalid';
+defaultConfig.oauth.client = { id: '1234', secret: '5678' };
+defaultConfig.oauth.auth = { tokenHost: 'http://dashboard.invalid/oauth/authorize' };
+defaultConfig.deployURL = 'http://repos.invalid';
+
+const userConfig = new Config(defaultConfig.userConfigPath);
+
+const token = {
+  access_token: '12345',
+  token_type: 'bearer',
+  expires_in: 7200,
+  refresh_token: '67890',
+  scope: 'mdk'
+};
+
+const accessToken = {
+  access_token: 'fffffff',
+  refresh_token: 'rrrrrrrr',
+  token_type: 'bearer',
+  expires_in: '7200'
+};
+
+chai.use(chaiHttp);
+const { expect } = chai;
+
+const app = server('tmp', 9999);
+
+describe('Acceptance: server/font-api', function() {
+  beforeEach(async function() {
+    await userConfig.append({ auth: { token } });
+  });
+
+  it('returns fonts from the server when available', async function() {
+    const customFonts = [
+      { id: 1, family: 'Roboto', webfont_url: 'https://example.com/roboto.woff' },
+      { id: 1, family: 'Libre', webfont_url: 'https://example.com/libre.woff' }
+    ];
+
+    nock('http://dashboard.invalid')
+      .get('/oauth/authorize')
+      .reply(function(uri, requestBody) {
+        const query = url.parse(uri, true).query;
+        return [302, '', { Location: `${query.redirect_uri}?code=auth%20code` }];
+      })
+      .post('/oauth/token')
+      .reply(200, {})
+      .get('/api/v2/custom_fonts')
+      .reply(200, JSON.stringify({ custom_fonts: customFonts }));
+
+    const res = await chai.request(app).get('/api/canvas/custom_fonts');
+
+    expect(res.body).to.deep.equal({ custom_fonts: customFonts });
+  });
+
+  it('returns an empty array when user is not logged in', async function() {
+    nock('http://dashboard.invalid')
+      .get('/api/v2/custom_fonts')
+      .reply(403, JSON.stringify({ error: 'not authorized' }));
+
+    const res = await chai.request(app).get('/api/canvas/custom_fonts');
+
+    expect(res).to.have.status(200);
+    expect(res.text).to.eq('{"custom_fonts":[]}');
+  });
+
+  it('returns an empty array when server cannot be reached', async function() {
+    nock('http://dashboard.invalid')
+      .get('/oauth/authorize')
+      .reply(function(uri, requestBody) {
+        const query = url.parse(uri, true).query;
+        return [302, '', { Location: `${query.redirect_uri}?code=auth%20code` }];
+      })
+      .post('/oauth/token')
+      .reply(200, accessToken)
+      .get('/api/v2/custom_fonts')
+      .reply(500, JSON.stringify({ error: 'bad response' }));
+
+    const res = await chai.request(app).get('/api/canvas/custom_fonts');
+
+    expect(res).to.have.status(200);
+    expect(res.text).to.eq('{"custom_fonts":[]}');
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -883,6 +883,16 @@ chai-files@^1.1.0:
   dependencies:
     assertion-error "^1.0.1"
 
+chai-http@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/chai-http/-/chai-http-4.0.0.tgz#810f579e98ae9d7847701759de7682361f2f286f"
+  dependencies:
+    cookiejar "^2.1.1"
+    is-ip "^2.0.0"
+    methods "^1.1.2"
+    qs "^6.5.1"
+    superagent "^3.7.0"
+
 chai@^3.3.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/chai/-/chai-3.5.0.tgz#4d02637b067fe958bdbfdd3a40ec56fef7373247"
@@ -1049,7 +1059,7 @@ component-emitter@1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.1.2.tgz#296594f2753daa63996d2af08d15a95116c9aec3"
 
-component-emitter@1.2.1:
+component-emitter@1.2.1, component-emitter@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
 
@@ -1142,6 +1152,10 @@ cookie-signature@1.0.6:
 cookie@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
+
+cookiejar@^2.1.0, cookiejar@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.2.tgz#dd8a235530752f988f9a0844f3fc589e3111125c"
 
 core-js@^2.4.0, core-js@^2.5.0:
   version "2.5.1"
@@ -1904,6 +1918,14 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
 
+form-data@^2.3.1, form-data@~2.3.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.2.tgz#4970498be604c20c005d4f5c23aecd21d6b49099"
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "1.0.6"
+    mime-types "^2.1.12"
+
 form-data@~2.1.1:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.1.4.tgz#33c183acf193276ecaa98143a69e94bfee1750d1"
@@ -1912,15 +1934,7 @@ form-data@~2.1.1:
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
 
-form-data@~2.3.1:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.2.tgz#4970498be604c20c005d4f5c23aecd21d6b49099"
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "1.0.6"
-    mime-types "^2.1.12"
-
-formidable@^1.2.1:
+formidable@^1.2.0, formidable@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.2.1.tgz#70fb7ca0290ee6ff961090415f4b3df3d2082659"
 
@@ -2374,6 +2388,10 @@ invariant@^2.2.2:
   dependencies:
     loose-envify "^1.0.0"
 
+ip-regex@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
+
 ip@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
@@ -2453,6 +2471,12 @@ is-glob@^3.1.0:
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-3.1.0.tgz#7ba5ae24217804ac70707b96922567486cc3e84a"
   dependencies:
     is-extglob "^2.1.0"
+
+is-ip@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-ip/-/is-ip-2.0.0.tgz#68eea07e8a0a0a94c2d080dd674c731ab2a461ab"
+  dependencies:
+    ip-regex "^2.0.0"
 
 is-number@^2.1.0:
   version "2.1.0"
@@ -3134,7 +3158,7 @@ merge@^1.1.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
 
-methods@~1.1.2:
+methods@^1.1.1, methods@^1.1.2, methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
 
@@ -3183,6 +3207,10 @@ mime-types@~2.1.17, mime-types@~2.1.18:
 mime@1.4.1, mime@^1.2.11:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz#121f9ebc49e3766f311a76e1fa1c8003c4b03aa6"
+
+mime@^1.4.1:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
 
 mimic-fn@^1.0.0:
   version "1.1.0"
@@ -3618,6 +3646,10 @@ process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
 
+process-nextick-args@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
+
 process-relative-require@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/process-relative-require/-/process-relative-require-1.0.0.tgz#1590dfcf5b8f2983ba53e398446b68240b4cc68a"
@@ -3762,6 +3794,18 @@ readable-stream@^2, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-str
     process-nextick-args "~1.0.6"
     safe-buffer "~5.1.1"
     string_decoder "~1.0.3"
+    util-deprecate "~1.0.1"
+
+readable-stream@^2.3.5:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
 readable-stream@~1.0.2:
@@ -4267,6 +4311,12 @@ string_decoder@~1.0.3:
   dependencies:
     safe-buffer "~5.1.0"
 
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
+  dependencies:
+    safe-buffer "~5.1.0"
+
 stringify-object-es5@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/stringify-object-es5/-/stringify-object-es5-2.5.0.tgz#057c3c9a90a127339bb9d1704a290bb7bd0a1ec5"
@@ -4325,6 +4375,21 @@ sum-up@^1.0.1:
   resolved "https://registry.yarnpkg.com/sum-up/-/sum-up-1.0.3.tgz#1c661f667057f63bcb7875aa1438bc162525156e"
   dependencies:
     chalk "^1.0.0"
+
+superagent@^3.7.0:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/superagent/-/superagent-3.8.3.tgz#460ea0dbdb7d5b11bc4f78deba565f86a178e128"
+  dependencies:
+    component-emitter "^1.2.0"
+    cookiejar "^2.1.0"
+    debug "^3.1.0"
+    extend "^3.0.0"
+    form-data "^2.3.1"
+    formidable "^1.2.0"
+    methods "^1.1.1"
+    mime "^1.4.1"
+    qs "^6.5.1"
+    readable-stream "^2.3.5"
 
 supports-color@4.4.0:
   version "4.4.0"


### PR DESCRIPTION
This adds support for using custom fonts configured in the user's company in the Movable Ink Dashboard.

Note that currently it only looks at fonts available to the user's primary company, not any other companies the user may have access to.