### PR TITLE
App API attributes

### DIFF
--- a/lib/server/pic-api.js
+++ b/lib/server/pic-api.js
@@ -49,6 +49,17 @@ module.exports = function picApi(root) {
   };
 };
 
+// convert time strings to milliseconds (30s -> 30000, 100ms -> 100)
+function ms(value) {
+  if (value && value.match(/ms$/)) {
+    return parseInt(value, 10);
+  } else if (value && value.match(/s$/)) {
+    return parseInt(value, 10) * 1000;
+  } else {
+    return null;
+  }
+}
+
 function responseObject(manifest) {
   const manifestRecord = Object.assign({}, manifest, {
     structure: manifest,
@@ -57,23 +68,36 @@ function responseObject(manifest) {
     id: 0
   });
 
+  const {
+    animation,
+    beta,
+    streaming,
+    timeout,
+    transparent,
+    cache_ttl
+  } = manifest.capture_options || {};
+
+  // perform the transformations that we perform internally when creating
+  // apps from a manifest
+  const picRecord = Object.assign({}, manifest, {
+    id: "local",
+    manifest_id: 0,
+    manifest_structure: manifestRecord,
+    beta,
+    timeout,
+    ttl: cache_ttl,
+    animated: !!animation,
+    animation_loop: !!(animation && animation.looping),
+    animation_interval: ms(animation && animation.interval),
+    animation_length: ms(animation && animation['length']),
+    animation_function: animation && animation.step_function,
+    animation_local_palette: (animation && animation.color_palette === "local"),
+    streaming,
+    transparent
+  });
+
   return {
-    custom_pics: [
-      {
-        html: manifest.html,
-        javascript: manifest.javascript,
-        css: manifest.css,
-        name: manifest.name,
-        id: "local",
-        manifest_id: 0,
-        width: manifest.width,
-        height: manifest.height,
-        fields: manifest.fields,
-        manifest_structure: manifestRecord
-      }
-    ],
-    manifests: [
-      manifestRecord
-    ]
+    custom_pics: [ picRecord ],
+    manifests: [ manifestRecord ]
   };
 }

--- a/lib/server/pic-api.js
+++ b/lib/server/pic-api.js
@@ -39,11 +39,12 @@ module.exports = function picApi(root) {
   return function(req, res) {
     loadResponse()
       .then(data => {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify(data));
       })
       .catch(err => {
         res.writeHead(500, {});
-        res.end(JSON.stringify(err));
+        res.end(JSON.stringify(err.message));
       });
   };
 };

--- a/tests/acceptance/server-pic-api-test.js
+++ b/tests/acceptance/server-pic-api-test.js
@@ -1,0 +1,51 @@
+const chai = require('chai');
+const chaiHttp = require('chai-http');
+const server = require('../../lib/server/index');
+const path = require('path');
+const tmp = require('ember-cli-internal-test-helpers/lib/helpers/tmp');
+const Promise = require('rsvp');
+const fs = require('fs-extra');
+const copy = Promise.denodeify(fs.copy);
+
+chai.use(chaiHttp);
+const { expect } = chai;
+
+let rootPath = process.cwd();
+let tmpPath = 'tmp';
+
+const app = server(path.resolve(tmpPath), 9999);
+
+async function setupManifest(name) {
+  await copy(path.join(rootPath, 'tests', 'data', 'style.css'),
+             path.join(tmpPath, 'style.css'),
+             { clobber: true });
+  await copy(path.join(rootPath, 'tests', 'data', 'manifests', name),
+             path.join(tmpPath, 'manifest.yml'),
+             { clobber: true });
+}
+
+describe('Acceptance: server/pic-api', function() {
+  it('returns animated properties from the manifest when they are set', async function() {
+    await setupManifest('simple.yml');
+
+    const res = await chai.request(app).get('/api/canvas/custom_pics/local');
+
+    expect(res.body.manifests.length).to.eq(1);
+    expect(res.body.manifests[0].name).to.eq('Simple');
+    expect(res.body.custom_pics.length).to.eq(1);
+    expect(res.body.custom_pics[0].name).to.eq('Simple');
+    expect(res.body.custom_pics[0].css.trim()).to.eq('html { color: green; }');
+    expect(res.body.custom_pics[0].animated).to.eq(false);
+  });
+
+  it('returns animated properties from advanced manifests', async function() {
+    await setupManifest('countdown.yml');
+    const res = await chai.request(app).get('/api/canvas/custom_pics/local');
+
+    expect(res.body.custom_pics.length).to.eq(1);
+    expect(res.body.custom_pics[0].name).to.eq('Countdown Timer (beta)');
+    expect(res.body.custom_pics[0].animated).to.eq(true);
+    expect(res.body.custom_pics[0].animation_length).to.eq(30000);
+    expect(res.body.custom_pics[0].animation_function).to.eq('requestCapturamaFrame();');
+  });
+});

--- a/tests/data/manifests/countdown.yml
+++ b/tests/data/manifests/countdown.yml
@@ -1,0 +1,107 @@
+---
+name: Countdown Timer (beta)
+authors:
+  - Movable Ink <dev@movableink.com>
+icon_v2: countdown-timer
+description: Build a Countdown Timer with a WYSIWYG interface
+documentation: https://support.movableink.com/hc/en-us/articles/360005409534
+category: 'context: time'
+javascript_file: dist/index.js
+html_file: app/index.html
+width: 400
+height: 300
+query_params:
+  mi_date: '[mi_date]'
+  mi_now: '[mi_now]'
+  mi_interval: '[mi_interval]'
+expose_advanced_options: true
+fields:
+  - name: filter_bad_words
+    label: Filter Bad Words
+    type: checkbox
+    value: false
+  - name: countdown_to
+    label: Countdown to Time
+    type: datetime
+    value: +3d
+studio_options:
+  framework_version: 0.1
+  prohibit_custom_params: true
+  preview_fields:
+    - date-time
+  tools: []
+  property_groups:
+    - name: countdown
+      label: Countdown Timer
+      description: Countdown Timer data
+      properties:
+        - name: countdown.days
+          label: Days Remaining
+          context_options: &countdown_context_options
+            - name: padNumbers
+              type: select
+              description: Show Leading "0"
+              options:
+                - value: false
+                  label: 'No'
+                - value: true
+                  label: 'Yes'
+            - &is_max_prop
+              name: isMaxProp
+              type: select
+              description: Is Largest Prop?
+              options:
+                - value: false
+                  label: 'No'
+                - value: true
+                  label: 'Yes'
+        - name: countdown.hours
+          label: Hours Remaining
+          context_options: *countdown_context_options
+        - name: countdown.minutes
+          label: Minutes Remaining
+          context_options: *countdown_context_options
+        - name: countdown.seconds
+          label: Seconds Remaining
+          context_options: *countdown_context_options
+        - name: countdown.daysDigit
+          label: Days Remaining Digit
+          context_options:
+            - *is_max_prop
+            - &digit_options
+              name: digitIndex
+              description: Digit to use
+              type: select
+              options:
+                - value: 0
+                  label: Ones Digit
+                - value: 1
+                  label: Tens Digit
+                - value: 2
+                  label: Hundreds Digit
+                - value: 3
+                  label: Thousands Digit
+        - name: countdown.hoursDigit
+          label: Hours Remaining Digit
+          context_options:
+            - *is_max_prop
+            - *digit_options
+        - name: countdown.minutesDigit
+          label: Minutes Remaining Digit
+          context_options:
+            - *is_max_prop
+            - *digit_options
+        - name: countdown.secondsDigit
+          label: Seconds Remaining Digit
+          context_options:
+            - *is_max_prop
+            - *digit_options
+capture_options:
+  timeout: 8s
+  cache_ttl: 5s
+  animation:
+    looping: true
+    interval: 1000ms
+    length: 30s
+    color_palette: global
+    step_function: requestCapturamaFrame();

--- a/tests/data/manifests/simple.yml
+++ b/tests/data/manifests/simple.yml
@@ -1,0 +1,13 @@
+name: Simple
+authors:
+  - Author Name <foo@example.com>
+html_file: app/index.html
+javascript_file: dist/index.js
+css_file: style.css
+description: Does not do much
+documentation: https://support.movableink.com/
+category: 'data: rendering'
+icon_v2: weather
+width: 250
+height: 200
+fields: []

--- a/tests/data/style.css
+++ b/tests/data/style.css
@@ -1,0 +1,1 @@
+html { color: green; }


### PR DESCRIPTION
We only supported previewing a few attributes (`html`, `css`, etc) in the preview; this adds all of the web crop options that manifests support such as animation. It also makes it correctly return content as `application/json`.