### PR TITLE
Studio should never show fallback warnings for MDK

### DIFF
--- a/lib/server/pic-api.js
+++ b/lib/server/pic-api.js
@@ -86,6 +86,7 @@ function responseObject(manifest) {
     beta,
     timeout,
     ttl: cache_ttl,
+    fallback_url: "_",
     animated: !!animation,
     animation_loop: !!(animation && animation.looping),
     animation_interval: ms(animation && animation.interval),


### PR DESCRIPTION
Studio warns if an app does not include a fallback; this does not apply to MDK because fallback can only be set within the platform. Shim a fake value (which is never used) to silence the warning.