### PR TITLE
Support `app-manifest.yml` in Movable CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 yarn-error.log
 tmp
+/.vscode

--- a/lib/server/save-api.js
+++ b/lib/server/save-api.js
@@ -1,7 +1,7 @@
 const path = require("path");
 const yaml = require("js-yaml");
 const fs = require("fs");
-const { readProjectFile, writeProjectFile } = require("./util");
+const { readProjectFile, writeProjectFile, projectFileExists } = require("./util");
 
 module.exports = function saveManifest(root) {
   return async function(req, res) {
@@ -21,12 +21,15 @@ module.exports = function saveManifest(root) {
     delete structure.css;
     delete structure.tabs;
 
-    const oldYaml = await readProjectFile(root, "manifest.yml");
+    const appManifestExists = await projectFileExists(root, "app-manifest.yml")
+    const manifestFile = appManifestExists ? "app-manifest.yml" : "manifest.yml";
+
+    const oldYaml = await readProjectFile(root, manifestFile);
     const newYaml = yaml.safeDump(structure, { noRefs: true });
 
     const outYaml = copyComments(oldYaml.toString(), newYaml);
 
-    await writeProjectFile(root, "manifest.yml", outYaml);
+    await writeProjectFile(root, manifestFile, outYaml);
 
     res.writeHead(204);
     res.end();

--- a/lib/server/util.js
+++ b/lib/server/util.js
@@ -4,6 +4,7 @@ const { promisify } = require("util");
 
 const readFile = promisify(fs.readFile);
 const writeFile = promisify(fs.writeFile);
+const exists = promisify(fs.exists);
 
 exports.writeProjectFile = function writeProjectFile(root, relativePath, data) {
   if (!data) {
@@ -24,6 +25,15 @@ exports.writeProjectFile = function writeProjectFile(root, relativePath, data) {
     throw "path outside of project directory: " + path;
   }
 };
+
+exports.projectFileExists = function projectFileExists(root, relativePath) {
+  const fullPath = path.resolve(root, relativePath);
+  if (fullPath.indexOf(root) === 0) {
+    return exists(fullPath);
+  } else {
+    throw "path outside of project directory: " + path;
+  }
+}
 
 exports.readProjectFile = function readProjectFile(root, relativePath) {
   const fullPath = path.resolve(root, relativePath);

--- a/lib/tasks/serve.js
+++ b/lib/tasks/serve.js
@@ -28,12 +28,20 @@ class ServeTask extends Task {
     });
 
     let watcherType = options && options.watcher;
+    let hasAppManifest = existsSync(path.join(this.project.root, 'app-manifest.yml'));
+
+    const ignored = [/^(node_modules|dist|tmp|app\/img)/];
+
+    if (hasAppManifest) {
+      ignored.push('manifest.yml');
+    }
+
     let saneWatcher = new (require('ember-cli-broccoli-sane-watcher'))(builder, {
       verbose: false,
       poll: watcherType === 'polling',
       watchman: watcherType === 'watchman' || watcherType === 'events',
       node: watcherType === 'node',
-      ignored: /^(node_modules|dist|tmp|app\/img)/
+      ignored
     });
 
     let watcher = options._watcher || new Watcher({

--- a/tests/acceptance/server-save-api-test.js
+++ b/tests/acceptance/server-save-api-test.js
@@ -1,0 +1,66 @@
+const chai = require("chai");
+const chaiHttp = require("chai-http");
+const server = require("../../lib/server/index");
+const path = require("path");
+const Promise = require("rsvp");
+const fs = require("fs-extra");
+const copy = Promise.denodeify(fs.copy);
+
+chai.use(chaiHttp);
+const { expect } = chai;
+
+let rootPath = process.cwd();
+let tmpPath = "tmp";
+
+const app = server(path.resolve(tmpPath), 9999);
+
+function manifestPath(fileName) {
+  return path.join(rootPath, "tests", "data", "manifests", fileName);
+}
+
+function appPath(fileName) {
+  return path.join(tmpPath, fileName);
+}
+
+async function setupManifest(name, targetName) {
+  await copy(manifestPath(name), appPath(targetName), {
+    clobber: true
+  });
+}
+
+describe("Acceptance: server/save-api", function() {
+  beforeEach(async () => {
+    await fs.remove('tmp');
+  });
+
+  it("saves changes to the manifest", async function() {
+    await setupManifest("simple.yml", "manifest.yml");
+
+    await chai
+      .request(app)
+      .put("/api/canvas/manifests/0")
+      .send({ manifest: { structure: { yaml: true } } });
+
+    const contents = fs.readFileSync(appPath('manifest.yml'));
+
+    expect(contents.toString()).to.eq("---\nyaml: true\n");
+  });
+
+  it("saves changes to the app-manifest if present, leaving manifest unchanged", async function() {
+    await setupManifest("simple.yml", "manifest.yml");
+    await setupManifest("simple.yml", "app-manifest.yml");
+
+    const ogManifest = fs.readFileSync(appPath('manifest.yml'));
+
+    await chai
+      .request(app)
+      .put("/api/canvas/manifests/0")
+      .send({ manifest: { structure: { yaml: true } } });
+
+      const afterManifest = fs.readFileSync(appPath('manifest.yml'));
+      const appManifest = fs.readFileSync(appPath('app-manifest.yml'));
+
+      expect(appManifest.toString()).to.eq("---\nyaml: true\n");
+      expect(ogManifest.toString()).to.eq(afterManifest.toString());
+  });
+});


### PR DESCRIPTION
Now that we have a build step for the `manifest.yml` file, we want to make sure that the MDK is doing the right thing. 

This PR does two things:

1. When saving changes to the manifest, save it to `app-manifest.yml` if it exists, otherwise save to `manifest.yml`
2. If the `app-manifest.yml` exists, do not watch the `manifest.yml` to trigger rebuilds. 