### PR TITLE
add missing exists-sync dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@movable/socketproxy": "^0.2.0",
     "ember-cli": "3.5.0",
+    "exists-sync": "0.0.4",
     "formidable": "^1.2.1",
     "http-proxy-middleware": "0.17.4",
     "js-yaml": "3.10.0",


### PR DESCRIPTION
Most npm installations end up having this dependency via some means, but in the event you start with a brand new `node` and install `@movable/cli`, this dependency will be missing since it is only a sub-dependency of our `devDependencies`. Move it to `dependencies` to make it explicit.

```
▶ movable new my-app
internal/modules/cjs/loader.js:584
    throw err;
    ^

Error: Cannot find module 'exists-sync'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:582:15)
    at Function.Module._load (internal/modules/cjs/loader.js:508:25)
    at Module.require (internal/modules/cjs/loader.js:637:17)
    at require (internal/modules/cjs/helpers.js:22:18)
    at Object.<anonymous> (/Users/user/.config/yarn/global/node_modules/@movable/cli/lib/tasks/serve.js:3:20)
    at Module._compile (internal/modules/cjs/loader.js:701:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:712:10)
    at Module.load (internal/modules/cjs/loader.js:600:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:539:12)
    at Function.Module._load (internal/modules/cjs/loader.js:531:3)
    at Module.require (internal/modules/cjs/loader.js:637:17)
    at require (internal/modules/cjs/helpers.js:22:18)
    at globSync.reduce (/Users/user/.config/yarn/global/node_modules/@movable/cli/node_modules/ember-cli/lib/utilities/require-as-hash.js:26:19)
    at Array.reduce (<anonymous>)
    at requireAsHash (/Users/user/.config/yarn/global/node_modules/@movable/cli/node_modules/ember-cli/lib/utilities/require-as-hash.js:24:52)
    at loadTasks (/Users/user/.config/yarn/global/node_modules/@movable/cli/lib/cli.js:40:14)
```