### PR TITLE
Cache rollup builds

### DIFF
--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -7,6 +7,7 @@ class Builder {
   constructor(opts) {
     this.options = opts;
     this.root = opts.project.root;
+    this.cache = [];
   }
 
   build(willReadStringDir, resultAnnotation) {
@@ -27,8 +28,11 @@ class Builder {
 
     return heimdall.node("rollup", () => {
       return RSVP.all(
-        buildConfig.map(config => {
+        buildConfig.map((config, index) => {
+          config.cache = this.cache[index];
+
           return rollup.rollup(config).then(bundle => {
+            this.cache[index] = bundle.cache;
             return bundle.write(config.output);
           });
         })


### PR DESCRIPTION
This sets up an internal build cache in `Builder` to speed up subsequent rollup builds. I initially considered using the `config` itself as the cache key, but it wasn't working in `studio-framework` apps. This uses the config index, and depends upon the config list not dynamically changing. (we do not ever reload the config after `movable` has started, so this is not an issue but something to look out for if we choose to rearchitect it in the future)